### PR TITLE
adds some needed steps

### DIFF
--- a/.github/workflows/update_tgui.yml
+++ b/.github/workflows/update_tgui.yml
@@ -11,6 +11,10 @@ jobs:
     concurrency: tgui
     runs-on: ubuntu-22.04
     steps:
+    - name: Install Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 14
     - name: Restore Yarn cache
       uses: actions/cache@v3
       with:
@@ -21,6 +25,7 @@ jobs:
           ${{ runner.os }}-
     - name: Update TGUI
       run: |
+        chmod +x tools/bootstrap/node
         tools/bootstrap/node tools/build/build.js tgui
     - name: Commit
       run: |


### PR DESCRIPTION
tools/bootstrap/node is set to 644 not 755 in repo so that won't work without chmodding it

also we need an explicit node version here because github loves changing the node version on the runners (remember https://github.com/Aurorastation/Aurora.3/pull/15858/)